### PR TITLE
Fix error in ease out quart easing function

### DIFF
--- a/RBBAnimation/RBBEasingFunction.m
+++ b/RBBAnimation/RBBEasingFunction.m
@@ -55,7 +55,7 @@ RBBEasingFunction const RBBEasingFunctionEaseInQuart = ^(CGFloat t) {
 };
 
 RBBEasingFunction const RBBEasingFunctionEaseOutQuart = ^(CGFloat t) {
-    return POW(t - 1, 4) + 1;
+    return 1 - POW(t - 1, 4);
 };
 
 RBBEasingFunction const RBBEasingFunctionEaseInOutQuart = ^(CGFloat t) {


### PR DESCRIPTION
Discovered the that the `RBBEasingFunctionEaseOutQuart` was actually outputting values between `2 - 1`. 
```
t = 0.0, POW (0 - 1, 4) + 1 = 2 
t = 0.5, POW (0.5 - 1, 4) + 1 = 1.0625
t = 1.0, POW (1 - 1, 4) + 1 = 1
```
```
t = 0.0, 1 - POW (0 - 1, 4) = 0
t = 0.5, 1 - POW (0.5 - 1, 4) + 1 = 0.9375
t = 1.0, 1 - POW (1 - 1, 4) + 1 = 1
```