### PR TITLE
CocoaPods 1.0 support - Drop the deprecated `exclusive` flag from Pod…

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-target 'RBBAnimationTest', :exclusive => true do
+target 'RBBAnimationTest' do
     platform :ios, '7.0'
 
     pod 'libextobjc/EXTScope', '0.4'
@@ -6,14 +6,14 @@ target 'RBBAnimationTest', :exclusive => true do
     pod 'libextobjc/EXTSynthesize'
 end
 
-target 'Specs-Mac', :exclusive => true do
+target 'Specs-Mac' do
   platform :osx, '10.8'
 
   pod 'Specta',  '~> 0.2.1'
   pod 'Expecta', '0.3'
 end
 
-target 'Specs-iOS', :exclusive => true do
+target 'Specs-iOS' do
   platform :ios, '6.0'
 
   pod 'Specta',  '~> 0.2.1'


### PR DESCRIPTION
CocoaPods 1.0 support - Drop the deprecated `exclusive` flag from Podfile

I just trying to run the sample app and facing a problem with the Podfile - Just need to remove a deprecated flag from the Podfile and now the pods installing fine.

Thanks,
bithug